### PR TITLE
[fix] name or id and change how option colors + value works

### DIFF
--- a/zite/database/create-record.mdx
+++ b/zite/database/create-record.mdx
@@ -1,10 +1,10 @@
 ---
 title: Create Record
-description: Creates a new record in a table.
+description: Creates a new record in a table using either table ID or table name.
 openapi: "/zite/database/openapi.json POST /bases/{databaseId}/tables/{tableId}/records"
 ---
 
-Creates a new record in a table with the provided field data.
+Creates a new record in a table with the provided field data using either the table ID or table name.
 
 <Note>
 Use field names or field IDs as keys and field values as data (e.g., `"Email": "user@example.com"` or `"fwtJyga6dso": "user@example.com"`)

--- a/zite/database/delete-record.mdx
+++ b/zite/database/delete-record.mdx
@@ -1,10 +1,10 @@
 ---
 title: Delete Record
-description: Permanently removes a record from a table.
+description: Permanently removes a record from a table using either table ID or table name.
 openapi: "/zite/database/openapi.json DELETE /bases/{databaseId}/tables/{tableId}/records/{recordId}"
 ---
 
-Permanently removes a record from the specified table.
+Permanently removes a record from the specified table using either the table ID or table name.
 
 <Warning>
   This action cannot be undone.

--- a/zite/database/delete-table.mdx
+++ b/zite/database/delete-table.mdx
@@ -1,10 +1,10 @@
 ---
 title: Delete Table
-description: Permanently deletes a table and all its records.
+description: Permanently deletes a table and all its records using either table ID or table name.
 openapi: "/zite/database/openapi.json DELETE /bases/{databaseId}/tables/{tableId}"
 ---
 
-Permanently removes a table and all its associated data from the database.
+Permanently removes a table and all its associated data from the database using either the table ID or table name.
 
 <Warning>
   Deleting a table will permanently remove the table, all its fields, views, and all records stored in the table. This action cannot be undone.

--- a/zite/database/field-types.mdx
+++ b/zite/database/field-types.mdx
@@ -249,10 +249,20 @@ string | null // Option label, e.g., "Active", "Pending", null
 {
   "name": "Status",
   "template": {
-    "options": ["Active", "Inactive", "Pending"]  // Array of option labels
+    "options": [
+      { "label": "Active", "color": "green" },
+      { "label": "Inactive", "color": "gray" },
+      { "label": "Pending", "color": "yellow" }
+    ]
   }
 }
 ```
+
+<Note>
+- `label` (required): The display text for the option
+- `color` (optional): Color key for the option. If not specified, a color will be auto-assigned. Available colors: purple, orange, blue, gray, red, yellow, green, pink, lime, tangerine, emerald, sky, teal, indigo, cyan, violet, fuchsia
+- `value` (optional): Not specified when creating new options. Useful in write operations when specifying existing options (e.g., reordering options, keeping old options and adding new ones)
+</Note>
 
 ---
 
@@ -275,10 +285,21 @@ string[] // Array of option labels, e.g., ["Urgent", "Bug"], []
 {
   "name": "Tags",
   "template": {
-    "options": ["Urgent", "Bug", "Feature", "Enhancement"]  // Array of option labels
+    "options": [
+      { "label": "Urgent", "color": "red" },
+      { "label": "Bug", "color": "orange" },
+      { "label": "Feature", "color": "blue" },
+      { "label": "Enhancement", "color": "purple" }
+    ]
   }
 }
 ```
+
+<Note>
+- `label` (required): The display text for the option
+- `color` (optional): Color key for the option. If not specified, a color will be auto-assigned. Available colors: purple, orange, blue, gray, red, yellow, green, pink, lime, tangerine, emerald, sky, teal, indigo, cyan, violet, fuchsia
+- `value` (optional): Not specified when creating new options. Useful in write operations when specifying existing options (e.g., reordering options, keeping old options and adding new ones)
+</Note>
 
 ---
 

--- a/zite/database/get-record-by-id.mdx
+++ b/zite/database/get-record-by-id.mdx
@@ -1,7 +1,7 @@
 ---
 title: Get Record by ID
-description: Retrieves a specific record by UUID.
+description: Retrieves a specific record by UUID using either table ID or table name.
 openapi: "/zite/database/openapi.json GET /bases/{databaseId}/tables/{tableId}/records/{recordId}"
 ---
 
-Fetches a single record by its unique identifier with all field data.
+Fetches a single record by its unique identifier with all field data using either the table ID or table name.

--- a/zite/database/list-records.mdx
+++ b/zite/database/list-records.mdx
@@ -1,10 +1,10 @@
 ---
 title: List Records
-description: Retrieves records from a table with filtering, sorting, and pagination.
+description: Retrieves records from a table with filtering, sorting, and pagination using either table ID or table name.
 openapi: "/zite/database/openapi.json POST /bases/{databaseId}/tables/{tableId}/records/list"
 ---
 
-Fetches records from a table with advanced filtering, sorting, and pagination options.
+Fetches records from a table with advanced filtering, sorting, and pagination options using either the table ID or table name.
 
 <Note>
 - Supports various filter operators (contains, in, not, lt, gt, etc.)

--- a/zite/database/openapi.json
+++ b/zite/database/openapi.json
@@ -195,7 +195,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier or name of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           }
         ],
         "requestBody": {
@@ -252,7 +252,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           }
         ],
         "responses": {
@@ -291,7 +291,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           }
         ],
         "requestBody": {
@@ -350,7 +350,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           },
           {
             "name": "fieldId",
@@ -359,7 +359,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier or name of the field to update"
+            "description": "The unique identifier of the field. You can also use the field name instead of the ID."
           }
         ],
         "requestBody": {
@@ -416,7 +416,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           },
           {
             "name": "fieldId",
@@ -425,7 +425,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier or name of the field. You cannot delete the primary field (the first field in a table)."
+            "description": "The unique identifier of the field. You can also use the field name instead of the ID. Note: You cannot delete the primary field (the first field in a table)."
           }
         ],
         "responses": {
@@ -464,7 +464,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           }
         ],
         "requestBody": {
@@ -523,7 +523,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           }
         ],
         "requestBody": {
@@ -582,7 +582,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           },
           {
             "name": "recordId",
@@ -639,7 +639,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           },
           {
             "name": "recordId",
@@ -706,7 +706,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The unique identifier of the table"
+            "description": "The unique identifier of the table. You can also use the table name instead of the ID."
           },
           {
             "name": "recordId",
@@ -1050,11 +1050,54 @@
           "name": "Status",
           "template": {
             "options": [
-              { "label": "Active", "color": "#10b981" },
-              { "label": "Inactive", "color": "#6b7280" }
+              {
+                "label": "Active",
+                "color": "green"
+              },
+              {
+                "label": "Inactive",
+                "color": "gray"
+              }
             ]
           }
         }
+      },
+      "FieldOption": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "The display text for the option"
+          },
+          "color": {
+            "type": "string",
+            "description": "Color key for the option. If not specified, a color will be auto-assigned. Available colors: purple, orange, blue, gray, red, yellow, green, pink, lime, tangerine, emerald, sky, teal, indigo, cyan, violet, fuchsia. Each color has a specific background and text color combination (e.g., purple uses #EEE6F3 background with #401DB3 text).",
+            "enum": [
+              "purple",
+              "orange",
+              "blue",
+              "gray",
+              "red",
+              "yellow",
+              "green",
+              "pink",
+              "lime",
+              "tangerine",
+              "emerald",
+              "sky",
+              "teal",
+              "indigo",
+              "cyan",
+              "violet",
+              "fuchsia"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for the option. Not specified when creating new options. Useful in write operations when specifying existing options (e.g., reordering options, keeping old options and adding new ones)."
+          }
+        },
+        "required": ["label"]
       },
       "UpdateFieldRequest": {
         "type": "object",

--- a/zite/database/update-record.mdx
+++ b/zite/database/update-record.mdx
@@ -1,10 +1,10 @@
 ---
 title: Update Record
-description: Updates an existing record's field values.
+description: Updates an existing record's field values using either table ID or table name.
 openapi: "/zite/database/openapi.json PATCH /bases/{databaseId}/tables/{tableId}/records/{recordId}"
 ---
 
-Modifies specific field values in an existing record.
+Modifies specific field values in an existing record using either the table ID or table name.
 
 <Note>
 Only provided fields will be updated

--- a/zite/database/update-table.mdx
+++ b/zite/database/update-table.mdx
@@ -1,10 +1,10 @@
 ---
 title: Update Table
-description: Updates table properties like name and order.
+description: Updates table properties like name and order using either table ID or table name.
 openapi: "/zite/database/openapi.json PATCH /bases/{databaseId}/tables/{tableId}"
 ---
 
-Modifies table properties including name and display order within the database.
+Modifies table properties including name and display order within the database using either the table ID or table name.
 
 <Note>
 - Only provided fields will be updated


### PR DESCRIPTION
Make the copy clear you can use id OR name for tableId / fieldID

Update the colors to be the specified list of colors we accept instead of hexcode.