### PR TITLE
Fix broken /help/ prefix in OpenAPI schema descriptions

### DIFF
--- a/database/openapi.json
+++ b/database/openapi.json
@@ -987,7 +987,7 @@
           "autonumber",
           "source"
         ],
-        "description": "Field type - see [Field Types Reference](/database/field-types) for complete list of available types and their configurations"
+        "description": "Field type - see [Field Types Reference](/help/database/field-types) for complete list of available types and their configurations"
       },
       "Database": {
         "type": "object",
@@ -1453,7 +1453,7 @@
           "filter": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Filter condition to query records. Supports nested AND/OR logic. Each condition requires `field` (field ID or name) and one operator (`equals`, `does_not_equal`, `contains`, `greater_than`, `in`, etc.). See [Filtering documentation](/database/list-records#filtering) for details.",
+            "description": "Filter condition to query records. Supports nested AND/OR logic. Each condition requires `field` (field ID or name) and one operator (`equals`, `does_not_equal`, `contains`, `greater_than`, `in`, etc.). See [Filtering documentation](/help/database/list-records#filtering) for details.",
             "example": {
               "field": "Status",
               "equals": "Active"


### PR DESCRIPTION
## Summary
- Two markdown links inside `database/openapi.json` schema descriptions used absolute domain paths (`/database/field-types`, `/database/list-records#filtering`) instead of the `/help/...` prefix, causing 404s since the docs are mounted at `/help/`.
- Mintlify rewrites internal absolute paths inside `.mdx` files automatically, but it does **not** rewrite paths inside OpenAPI description fields — those have to be written explicitly with `/help/`. The four other `/help/database/field-types` references in the same file were already correct; these two were missed.

## Test plan
- [ ] Visit a generated API page (e.g. `https://www.zite.com/help/database/api/get-database-by-id`) and click the `Field Types Reference` link in the field schema — should land on `/help/database/field-types`.
- [ ] On the list-records API page, click the `Filtering documentation` link in the `filter` parameter — should land on `/help/database/list-records#filtering`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help documentation links in API schema to reference the new help pages, providing improved access to support resources for API field types and filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->