### PR TITLE
Fix video fullscreen and support banner alignment

### DIFF
--- a/airtable-signature-form.mdx
+++ b/airtable-signature-form.mdx
@@ -11,7 +11,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 This video walks through how to make a form that uploads signatures to Airtable using the Fillout form builder.
 
-<iframe width="100%" height="420" src="https://www.youtube.com/embed/g9mzuoRVsm0" title="Collect e-signatures with Airtable and Fillout" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.youtube.com/embed/g9mzuoRVsm0" title="Collect e-signatures with Airtable and Fillout" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Overview
 

--- a/airtable-update-form.mdx
+++ b/airtable-update-form.mdx
@@ -11,7 +11,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 Check out [Gareth](https://www.garethpronovost.com/)’s tutorial on using Fillout to update existing Airtable records.
 
-<iframe width="720" height="420" src="https://www.youtube.com/embed/mvDQBif-sbE" title="Updating Airtable records with advanced Fillout forms" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="720" height="420" src="https://www.youtube.com/embed/mvDQBif-sbE" title="Updating Airtable records with advanced Fillout forms" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## How it works
 

--- a/airtable.mdx
+++ b/airtable.mdx
@@ -15,7 +15,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 Check out this tutorial on using Fillout to create or update an Airtable base.
 
-<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/m1vsI_99pgs" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/m1vsI_99pgs" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/approval-workflows.mdx
+++ b/approval-workflows.mdx
@@ -7,7 +7,7 @@ icon: "badge-check"
 
 import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
-<iframe width="100%" height="420" src="https://www.youtube.com/embed/cy5L4XMGUdk" title="Introducing Fillout Approvals" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.youtube.com/embed/cy5L4XMGUdk" title="Introducing Fillout Approvals" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## How to automate approvals
 

--- a/calculations.mdx
+++ b/calculations.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe width="720" height="420" src="https://www.youtube.com/embed/51JXFjaZF6k" title="How to add calculations to your form" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="720" height="420" src="https://www.youtube.com/embed/51JXFjaZF6k" title="How to add calculations to your form" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 import { Arcade } from '/snippets/Arcade.mdx';
 

--- a/combine-and-repeat-forms.mdx
+++ b/combine-and-repeat-forms.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe src="https://www.loom.com/embed/294b87e92afa4de78e005a30ee29d41b" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540px" />
+<iframe src="https://www.loom.com/embed/294b87e92afa4de78e005a30ee29d41b" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540px" />
 
 ## Auto-redirect to another form
 

--- a/conditional-hiding.mdx
+++ b/conditional-hiding.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/6d48f8de3d7d493d8a44cf66aaff4723" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540px" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/6d48f8de3d7d493d8a44cf66aaff4723" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540px" />
 
 ## Hide based on a condition
 

--- a/create-multiple-records-with-form.mdx
+++ b/create-multiple-records-with-form.mdx
@@ -13,7 +13,7 @@ If you want the respondent to choose how many linked records they would like to 
 
 You can fully customize the form that appears for adding the linked records.
 
-<iframe width="100%" height="420" src="https://www.loom.com/embed/5000bc8b87c74acca5fe5cd96fecf3e4" title="Create new linked records with a subform" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.loom.com/embed/5000bc8b87c74acca5fe5cd96fecf3e4" title="Create new linked records with a subform" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Option 2: Combine multiple forms
 

--- a/create-new-linked-records.mdx
+++ b/create-new-linked-records.mdx
@@ -11,7 +11,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 Below is a tutorial video on how to create new [Airtable records](https://www.airtable.com/guides/build/connect-data-with-linked-records) from a linked record picker in Fillout.
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/5000bc8b87c74acca5fe5cd96fecf3e4" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/5000bc8b87c74acca5fe5cd96fecf3e4" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## Create new linked records
 

--- a/custom-domains.mdx
+++ b/custom-domains.mdx
@@ -13,7 +13,7 @@ A **custom domain** is a unique web address to replace your web form's default U
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/2e59bfc897734511b849d1c97c7ab695" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/2e59bfc897734511b849d1c97c7ab695" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540" />
 
 ## How to add a custom domain
 

--- a/custom-emails.mdx
+++ b/custom-emails.mdx
@@ -98,7 +98,7 @@ To change the text formatting and color, or add a hyperlink, simply highlight an
 
 Here's a quick way to show your respondents a summary of their form submission.
 
-<iframe width="100%" height="420" src="https://www.youtube.com/embed/o48m_x3Pg84" title="Fillout Workflows - Email Notifications" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.youtube.com/embed/o48m_x3Pg84" title="Fillout Workflows - Email Notifications" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Related articles
 

--- a/custom-link.mdx
+++ b/custom-link.mdx
@@ -17,7 +17,7 @@ You can customize your form link to make it more recognizable and aligned with y
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/2e59bfc897734511b849d1c97c7ab695" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/2e59bfc897734511b849d1c97c7ab695" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540" />
 
 ## How to add a custom subdomain
 

--- a/dropbox.mdx
+++ b/dropbox.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe src="https://www.youtube.com/embed/9btbb2SAtY0?feature=oembed" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe src="https://www.youtube.com/embed/9btbb2SAtY0?feature=oembed" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/email-form.mdx
+++ b/email-form.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/541f6b219ab248a7ab5748c3b794f693" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420px" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/541f6b219ab248a7ab5748c3b794f693" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420px" />
 
 ## How to send your form via email
 

--- a/embed-fillout-softr.mdx
+++ b/embed-fillout-softr.mdx
@@ -61,7 +61,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 Watch Dan Leeman from [Automation Helpers](https://www.automationhelpers.com/templates/build-filtered-forms-with-softr-and-fillout) build a filtered Fillout form, embedded in Softr.
 
-<iframe width="100%" height="420" src="https://www.youtube.com/embed/8iNqptGxO4U" title="Build Filtered Forms with Softr and Fillout" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.youtube.com/embed/8iNqptGxO4U" title="Build Filtered Forms with Softr and Fillout" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Update forms
 

--- a/embed-form-in-squarespace.mdx
+++ b/embed-form-in-squarespace.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/eb07f1f17c2b4d92afc4096960d7b212" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540px" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/eb07f1f17c2b4d92afc4096960d7b212" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540px" />
 
 ## How to embed your form
 

--- a/embed-form-in-webflow.mdx
+++ b/embed-form-in-webflow.mdx
@@ -13,7 +13,7 @@ While [Webflow](https://webflow.com) has some built-in form features, they have 
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/615d4eab46b8400aaecfccd057ed3c96" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/615d4eab46b8400aaecfccd057ed3c96" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540" />
 
 ## How to embed your form
 

--- a/embed-forms-in-wix.mdx
+++ b/embed-forms-in-wix.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/2576cbfd563f48e8953374bf280c7b57" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/2576cbfd563f48e8953374bf280c7b57" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540" />
 
 ## How to embed your form
 

--- a/fillout.mdx
+++ b/fillout.mdx
@@ -11,7 +11,7 @@ import { SupportBanner } from '/snippets/SupportBanner.mdx';
 
 The very basics of Fillout, in a 2 minute video. For an in-depth tutorial on how to make forms, check [this guide](https://www.fillout.com/help/make-a-form).
 
-<iframe src="https://www.youtube.com/embed/ZhdKHlztgsk" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+<iframe src="https://www.youtube.com/embed/ZhdKHlztgsk" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen />
 
 ## Quick Start
 

--- a/google-sheets.mdx
+++ b/google-sheets.mdx
@@ -14,7 +14,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video Tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/lD4h82s0LeE?feature=shared" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/lD4h82s0LeE?feature=shared" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/hubspot.mdx
+++ b/hubspot.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe src="https://www.youtube.com/embed/V6ZIKISqmHk" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+<iframe src="https://www.youtube.com/embed/V6ZIKISqmHk" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen />
 
 ## How it works
 

--- a/lead-enrichment.mdx
+++ b/lead-enrichment.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Tutorial video
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/08f91f725a7a4aff95ae2a14d6928608" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/08f91f725a7a4aff95ae2a14d6928608" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540" />
 
 <Info>
   Lead enrichment is part of the conversion kit paid add-on. Fillout covers the costs for external APIs like Clearbit and Google Maps - **no API key needed**. Get started [here](https://www.fillout.com/conversion-kit).

--- a/login-page.mdx
+++ b/login-page.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video overview
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/065be1b4f5bf47d887630111c1ad8a0e" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540px" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/065be1b4f5bf47d887630111c1ad8a0e" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540px" />
 
 ## Add a login page
 

--- a/mailchimp.mdx
+++ b/mailchimp.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/fe29e184935b49faa0f567a75464f4cd?hideEmbedTopBar=true" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/fe29e184935b49faa0f567a75464f4cd?hideEmbedTopBar=true" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/make-a-form-in-any-language.mdx
+++ b/make-a-form-in-any-language.mdx
@@ -65,7 +65,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video overview
 
-<iframe width="760" height="515" src="https://www.youtube.com/embed/q6Hco-VU6bM?si=VqygRQ6hvQyMtku4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="760" height="515" src="https://www.youtube.com/embed/q6Hco-VU6bM?si=VqygRQ6hvQyMtku4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## How to change form language
 

--- a/make-a-free-quiz.mdx
+++ b/make-a-free-quiz.mdx
@@ -19,7 +19,7 @@ With Fillout, you can easily create and customize your own **free quiz** that le
 
 Give the demo quiz below a try to get an idea of the types of quizzes you can make with Fillout. This is just one example - the Fillout quiz builder is highly customizable.
 
-<iframe class="notion-asset-object-fit" src="https://forms.fillout.com/t/fLr5WSFq7nus" title="iframe embed" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="740" />
+<iframe class="notion-asset-object-fit" src="https://forms.fillout.com/t/fLr5WSFq7nus" title="iframe embed" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="740" />
 
 ## How to create a quiz in Fillout
 

--- a/make-forms-that-convert.mdx
+++ b/make-forms-that-convert.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 Here's an overview of the Conversion Kit by Dan Leeman and the team at [Automation Helpers](https://www.automationhelpers.com/).
 
-<iframe width="720" height="420" src="https://www.youtube.com/embed/Qh-B75Pnf-M" title="Pump Up Your Lead Conversions with Fillout's Conversion Kit 🎯" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="720" height="420" src="https://www.youtube.com/embed/Qh-B75Pnf-M" title="Pump Up Your Lead Conversions with Fillout's Conversion Kit 🎯" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 With the **conversion kit**, you can:
 

--- a/monday.mdx
+++ b/monday.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/wEnbsSVG0WQ" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/wEnbsSVG0WQ" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/notion.mdx
+++ b/notion.mdx
@@ -15,7 +15,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/44ff36a3a09e4fbdb45f32117c0318b9" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="540" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/44ff36a3a09e4fbdb45f32117c0318b9" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="540" />
 
 ## How it works
 

--- a/page-logic.mdx
+++ b/page-logic.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/221e4df32658448caa83f0a2b5e73efb" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420px" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/221e4df32658448caa83f0a2b5e73efb" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420px" />
 
 ## Edit page branching
 

--- a/pdfs.mdx
+++ b/pdfs.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/417PJJ8DJHU" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/417PJJ8DJHU" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/record-pickers.mdx
+++ b/record-pickers.mdx
@@ -44,19 +44,19 @@ This field is great for avoiding duplicate entries, keeping your data organized 
 
 You can [pre-fill](/prefill-fields) a record picker using the record's Airtable **Record ID.** In this video, we show how to pre-fill a record picker using a [URL parameter](/url-parameters).
 
-<iframe width="100%" height="420" src="https://www.loom.com/embed/24945c50cd9a4fc7b3815e7fae10c1ad" title="How to pre-fill a record picker" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.loom.com/embed/24945c50cd9a4fc7b3815e7fae10c1ad" title="How to pre-fill a record picker" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Prevent respondents from changing the record picker
 
 You can choose to always [conditionally hide](/conditional-hiding) the record picker.
 
-<iframe width="100%" height="420" src="https://www.loom.com/embed/065000ec7101425888c59038225060f3" title="How to stop users from changing the record picker by hiding it" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.loom.com/embed/065000ec7101425888c59038225060f3" title="How to stop users from changing the record picker by hiding it" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Reference fields from the chosen Airtable record
 
 Personalize your form by referencing fields in your form.
 
-<iframe width="100%" height="420" src="https://www.loom.com/embed/35d7a05424994030b4a54c25036c4c40" title="How to reference fields from the chosen Airtable record" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.loom.com/embed/35d7a05424994030b4a54c25036c4c40" title="How to reference fields from the chosen Airtable record" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Advanced customizations
 

--- a/round-robin.mdx
+++ b/round-robin.mdx
@@ -15,7 +15,7 @@ Round robin scheduling allocates appointments among hosts based on availability 
 
 Check out [Gareth](https://www.garethpronovost.com/)’s tutorial on Fillout’s round robin scheduling feature.
 
-<iframe width="100%" height="420" src="https://www.youtube.com/embed/iuTeqoFWtgs" title="Hot New Fillout Feature 🔥 Round Robin Scheduler" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.youtube.com/embed/iuTeqoFWtgs" title="Hot New Fillout Feature 🔥 Round Robin Scheduler" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## How to set up
 

--- a/salesforce.mdx
+++ b/salesforce.mdx
@@ -13,7 +13,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/c9e1d9e4470446fb97501d31b843c472" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/c9e1d9e4470446fb97501d31b843c472" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/select-linked-airtable-records.mdx
+++ b/select-linked-airtable-records.mdx
@@ -11,7 +11,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 In Fillout, you can even filter which records a respondent is choosing from. Here's how.
 
-<iframe width="100%" height="420" src="https://www.loom.com/embed/0b693e23011647ff880973b55489a16b" title="Select & Filter Airtable Linked Records in a Dropdown" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+<iframe width="100%" height="420" src="https://www.loom.com/embed/0b693e23011647ff880973b55489a16b" title="Select & Filter Airtable Linked Records in a Dropdown" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 
 ## Enable dropdown filtering
 

--- a/slack.mdx
+++ b/slack.mdx
@@ -14,7 +14,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 ## Video tutorial
 
 
-  <iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/a619078ed5ec4d31bb9ee3d99fb62314" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+  <iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/a619078ed5ec4d31bb9ee3d99fb62314" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 
 ## How it works

--- a/smartsuite.mdx
+++ b/smartsuite.mdx
@@ -17,7 +17,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/b9fb55da189641c5b8bae8a2d60d80d6?hideEmbedTopBar=true" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.loom.com/embed/b9fb55da189641c5b8bae8a2d60d80d6?hideEmbedTopBar=true" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/stripe-payments-to-airtable.mdx
+++ b/stripe-payments-to-airtable.mdx
@@ -9,7 +9,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/Izty_dqvn3M" title="iframe video" frameborder="0" allowfullscreen loading="lazy" scrolling="auto" width="100%" height="420" />
+<iframe class="notion-asset-object-fit" src="https://www.youtube.com/embed/Izty_dqvn3M" title="iframe video" frameborder="0" allowFullScreen loading="lazy" scrolling="auto" width="100%" height="420" />
 
 ## How it works
 

--- a/style.css
+++ b/style.css
@@ -161,18 +161,18 @@ div.px-1.flex.flex-wrap.gap-2.text-secondary span.inline-block.rounded-lg.text-s
     position: absolute;
     z-index: 1;
     inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     text-align: center;
 }
 
 .support-banner__title {
-    position: absolute;
-    top: 26%;
-    left: 50%;
     display: flex;
     width: 100%;
     margin: 0;
     justify-content: center;
-    transform: translateX(-50%);
     color: #000;
     font-size: clamp(28px, 5.07cqi, 72px) !important;
     font-weight: 600;
@@ -181,12 +181,8 @@ div.px-1.flex.flex-wrap.gap-2.text-secondary span.inline-block.rounded-lg.text-s
 }
 
 .support-banner__copy {
-    position: absolute;
-    top: 48%;
-    left: 50%;
     width: 100%;
-    margin: 0;
-    transform: translateX(-50%);
+    margin: clamp(20px, 3.38cqi, 48px) 0 0;
     color: #000;
     font-size: clamp(16px, 2.11cqi, 30px) !important;
     font-weight: 400;
@@ -242,15 +238,12 @@ div.px-1.flex.flex-wrap.gap-2.text-secondary span.inline-block.rounded-lg.text-s
 
 .support-banner__cta,
 .support-banner__cta:hover {
-    position: absolute;
-    top: 72%;
-    left: 50%;
     display: inline-flex;
     width: max(14.23cqi, 116px);
     height: max(4.01cqi, 38px);
+    margin-top: clamp(18px, 2.68cqi, 38px);
     align-items: center;
     justify-content: center;
-    transform: translateX(-50%);
     border-radius: max(1.27cqi, 14px);
     background: #0D151A;
     color: #FFFBFB !important;

--- a/styling.mdx
+++ b/styling.mdx
@@ -8,7 +8,7 @@ icon: "circle-info"
 import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 <Frame>
-  <iframe width="100%" height="420" src="https://www.youtube.com/embed/XDvfwbFE3zI" title="How to customize your form, survey, or quiz" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+  <iframe width="100%" height="420" src="https://www.youtube.com/embed/XDvfwbFE3zI" title="How to customize your form, survey, or quiz" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowFullScreen />
 </Frame>
 
 

--- a/url-parameters.mdx
+++ b/url-parameters.mdx
@@ -17,7 +17,7 @@ import { SupportBanner } from "/snippets/SupportBanner.mdx";
 
 ## Video tutorial
 
-<iframe src="https://www.youtube.com/embed/3mK2AGcjzfk" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+<iframe src="https://www.youtube.com/embed/3mK2AGcjzfk" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen />
 
 ## How to add a URL parameter or hidden field
 


### PR DESCRIPTION
## Summary
- update rendered MDX iframes to use React’s `allowFullScreen` attribute
- vertically center the reusable support banner content as one responsive stack
- preserve the lowercase `allowfullscreen` spelling in the DOM `setAttribute` example, where it is correct

## Why
Embedded videos could not be expanded to fullscreen, and the support banner’s title, copy, and CTA appeared too low within the yellow container.

## Root cause
The iframe markup used the lowercase HTML attribute in JSX/MDX instead of React’s camel-cased property. The banner also positioned each content element independently with percentage offsets, so the group did not remain vertically centered across widths.

## Impact
Users can enter fullscreen mode on embedded videos, and the support banner content remains centered responsively.

## Validation
- `mintlify validate`
- `git diff --check`
- audited all rendered MDX iframes for `allowFullScreen`
- visually verified the banner on the local Quickstart page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen support and compatibility across embedded tutorial and demo videos.
  * Updated video embeds throughout the documentation to use consistent fullscreen permissions.

* **Style**
  * Improved responsive layout and spacing for the Quickstart support banner across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->